### PR TITLE
Add `validate-commit-msg` and run lint before `git commit`

### DIFF
--- a/.vcmrc
+++ b/.vcmrc
@@ -1,0 +1,18 @@
+{
+  "types": [
+    "feat",
+    "fix",
+    "docs",
+    "style",
+    "refactor",
+    "example",
+    "perf",
+    "test",
+    "chore",
+    "revert"
+  ],
+  "warnOnFail": false,
+  "subjectPattern": ".+",
+  "subjectPatternErrorMsg": "Subject does not match subject pattern!",
+  "helpMessage": "\n# Allowed type: feat, fix, docs, style, refactor, example, perf, test, chore, revert."
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:commonjs": "rm -rf lib/;tsc",
     "build:umd": "rm -rf dist;webpack",
     "test": "rm -rf lib/test;tsc;mocha lib/test/**/*_test.js --timeout 5000 --bail --exit",
-    "lint": "tslint -c tslint.json 'src/**/*.ts'",
+    "lint": "tslint -p tsconfig.json -c tslint.json 'src/**/*.ts'",
     "precommit": "npm run lint",
     "commitmsg": "validate-commit-msg"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
   "scripts": {
     "build:commonjs": "rm -rf lib/;tsc",
     "build:umd": "rm -rf dist;webpack",
-    "test": "rm -rf lib/test;tsc;mocha lib/test/**/*_test.js --timeout 5000 --bail --exit"
+    "test": "rm -rf lib/test;tsc;mocha lib/test/**/*_test.js --timeout 5000 --bail --exit",
+    "lint": "tslint -c tslint.json 'src/**/*.ts'",
+    "precommit": "npm run lint",
+    "commitmsg": "validate-commit-msg"
   },
   "repository": {
     "type": "git",
@@ -34,6 +37,7 @@
     "ts-loader": "^2.3.7",
     "tslint": "^5.7.0",
     "typescript": "^2.5.3",
+    "validate-commit-msg": "^2.14.0",
     "webpack": "^3.6.0",
     "webpack-dev-server": "^2.9.1"
   },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/chai": "^4.0.4",
     "@types/jasmine": "^2.6.0",
     "chai": "^4.1.2",
+    "husky": "^0.14.3",
     "jasmine-core": "^2.8.0",
     "json-loader": "^0.5.7",
     "karma": "^1.7.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-document.write("It works.");
+document.write('It works.');

--- a/tslint.json
+++ b/tslint.json
@@ -137,7 +137,6 @@
       "check-preblock",
       "check-separator",
       "check-type"
-    ],
-    "no-access-missing-member": true
+    ]
   }
 }


### PR DESCRIPTION
The usage of `validate-commit-msg` 
`git commit -m "type: message"`. Allowed type: feat, fix, docs, style, refactor, example, perf, test, chore, revert.
eg: `git commit -m "feat: add validate-commit-msg and run lint before the commit"`